### PR TITLE
solve rcmdcheck warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,17 +9,20 @@ Author: c(
 Maintainer: Ruben Dries <rubendries@gmail.com>
 Description: Stores information and scripts to work with, or load various
     different spatial datasets that can be used with the Giotto Suite workflow.
-    Also contains example mini Giotto subobjects
+    Also contains example mini Giotto subobjects.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 URL: https://drieslab.github.io/GiottoData/, https://github.com/drieslab/GiottoData
 BugReports: https://github.com/drieslab/GiottoData/issues
 Depends:
-    R (>= 3.5.0),
-    Giotto (>= 3.0.0)
+    R (>= 3.5.0)
 Imports:
-    utils (>= 3.5.0),
     data.table (>= 1.14.0),
-    terra (>= 1.5-12)
+    ggplot2,
+    Giotto (>= 3.0.0),
+    GiottoClass,
+    GiottoUtils,
+    terra (>= 1.5-12),
+    utils (>= 3.5.0)
 RoxygenNote: 7.2.3

--- a/R/dataset_helpers.R
+++ b/R/dataset_helpers.R
@@ -33,8 +33,8 @@ loadGiottoMini = function(dataset = c('visium', 'seqfish', 'starmap', 'vizgen', 
 
   if(dataset == 'vizgen') {
     mini_gobject = Giotto::loadGiotto(path_to_folder = system.file('/Mini_datasets/Vizgen/VizgenObject/', package = 'GiottoData'),
-                              python_path = python_path,
-                              reconnect_giottoImage = FALSE)
+                                      python_path = python_path,
+                                      reconnect_giottoImage = FALSE)
   }
 
   if(dataset == 'cosmx') {
@@ -45,29 +45,26 @@ loadGiottoMini = function(dataset = c('visium', 'seqfish', 'starmap', 'vizgen', 
 
 
   if(dataset == 'seqfish') {
-    Giotto:::wrap_msg('To be implemented \n')
+    GiottoUtils::wrap_msg('To be implemented \n')
   }
 
   if(dataset == 'starmap') {
     mini_gobject = Giotto::loadGiotto(path_to_folder = system.file('/Mini_datasets/3D_starmap/3DStarmapObject/', package = 'GiottoData'),
-                              python_path = python_path)
-    }
+                                      python_path = python_path)
+  }
 
   if(dataset == 'spatialgenomics') {
     mini_gobject = Giotto::loadGiotto(path_to_folder = system.file('/Mini_datasets/SpatialGenomics/SpatialGenomicsObject/', package = 'GiottoData'),
-                              python_path = python_path)
+                                      python_path = python_path)
   }
 
 
   # 1. change default instructions
-  identified_python_path = set_giotto_python_path(python_path = python_path)
+  identified_python_path = GiottoClass::set_giotto_python_path(python_path = python_path)
   print(identified_python_path)
-  mini_gobject = changeGiottoInstructions(gobject = mini_gobject,
+  mini_gobject = GiottoClass::changeGiottoInstructions(gobject = mini_gobject,
                                           params = c('show_plot', 'return_plot', 'save_plot', 'save_dir'),
-                                          new_values = c(TRUE, FALSE, FALSE, NA)
-                                          #params = c('python_path', 'show_plot', 'return_plot', 'save_plot', 'save_dir'),
-                                          #new_values = c(identified_python_path, TRUE, FALSE, FALSE, getwd())
-                                          )
+                                          new_values = c(TRUE, FALSE, FALSE, NA) )
 
   return(mini_gobject)
 
@@ -125,7 +122,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
                                                      'sg_mini_kidney'))
 
   # check operating system first
-  os_specific_system = Giotto:::get_os()
+  os_specific_system = GiottoUtils::get_os()
 
   #if(os_specific_system == 'windows') {
   #  stop('This function is currently not supported on windows systems,
@@ -169,7 +166,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
   selection = datasets_file[['dataset']] == sel_dataset
   selected_dataset_info = datasets_file[selection,]
   if(verbose) {
-    Giotto:::wrap_msg('Selected dataset links for: ', sel_dataset, ' \n \n')
+    GiottoUtils::wrap_msg('Selected dataset links for: ', sel_dataset, ' \n \n')
     print(selected_dataset_info)
   }
 
@@ -177,12 +174,12 @@ getSpatialDataset = function(dataset = c('ST_OB1',
 
   # get url to expression matrix and download
   if(verbose) {
-    Giotto:::wrap_msg("\n \n Download expression matrix: \n")
+    GiottoUtils::wrap_msg("\n \n Download expression matrix: \n")
   }
   expr_matrix_url = selected_dataset_info[['expr_matrix']]
 
   if(expr_matrix_url == "") {
-    Giotto:::wrap_msg('\n No expression found, skip this step \n')
+    GiottoUtils::wrap_msg('\n No expression found, skip this step \n')
   } else {
 
     expr_matrix_url = unlist(strsplit(expr_matrix_url, split = '\\|'))
@@ -192,7 +189,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
       mydestfile = paste0(directory,'/', myfilename)
 
       if(dryrun) {
-        Giotto:::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
+        GiottoUtils::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
       } else {
         utils::download.file(url = url, destfile = mydestfile, ...)
       }
@@ -207,13 +204,13 @@ getSpatialDataset = function(dataset = c('ST_OB1',
 
   # get url to spatial locations and download
   if(verbose) {
-    Giotto:::wrap_msg("\n \n Download spatial locations: \n")
+    GiottoUtils::wrap_msg("\n \n Download spatial locations: \n")
   }
 
   spatial_locs_url = selected_dataset_info[['spatial_locs']]
 
   if(spatial_locs_url == "") {
-    Giotto:::wrap_msg('\n No spatial locations found, skip this step \n')
+    GiottoUtils::wrap_msg('\n No spatial locations found, skip this step \n')
   } else {
 
     spatial_locs_url = unlist(strsplit(spatial_locs_url, split = '\\|'))
@@ -223,7 +220,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
       mydestfile = paste0(directory,'/', myfilename)
 
       if(dryrun) {
-        Giotto:::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
+        GiottoUtils::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
       } else {
         utils::download.file(url = url, destfile = mydestfile, ...)
       }
@@ -236,14 +233,14 @@ getSpatialDataset = function(dataset = c('ST_OB1',
 
   # get url(s) to additional metadata files and download
   if(verbose) {
-    Giotto:::wrap_msg("\n \n Download metadata: \n")
+    GiottoUtils::wrap_msg("\n \n Download metadata: \n")
   }
 
   #metadata_url = selected_dataset_info[['metadata']][[1]]
   metadata_url = selected_dataset_info[['metadata']]
 
   if(metadata_url == "") {
-    Giotto:::wrap_msg('\n No metadata found, skip this step \n')
+    GiottoUtils::wrap_msg('\n No metadata found, skip this step \n')
   } else {
 
     metadata_url = unlist(strsplit(metadata_url, split = '\\|'))
@@ -253,7 +250,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
       mydestfile = paste0(directory,'/', myfilename)
 
       if(dryrun) {
-        Giotto:::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
+        GiottoUtils::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
       } else {
         utils::download.file(url = url, destfile = mydestfile, ...)
       }
@@ -269,11 +266,11 @@ getSpatialDataset = function(dataset = c('ST_OB1',
   spatial_seg_url = selected_dataset_info[['segmentations']]
 
   if(spatial_seg_url == "") {
-    # Giotto:::wrap_msg('\n No segmentations found, skip this step \n')
+    # GiottoUtils::wrap_msg('\n No segmentations found, skip this step \n')
   } else {
 
     if(verbose) {
-      Giotto:::wrap_msg("\n \n Download segmentations: \n")
+      GiottoUtils::wrap_msg("\n \n Download segmentations: \n")
     }
 
     spatial_seg_url = unlist(strsplit(spatial_seg_url, split = '\\|'))
@@ -283,7 +280,7 @@ getSpatialDataset = function(dataset = c('ST_OB1',
       mydestfile = paste0(directory,'/', myfilename)
 
       if(dryrun) {
-        Giotto:::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
+        GiottoUtils::wrap_msg("utils::download.file(url = ", url, ", destfile = ", mydestfile, ", ...)")
       } else {
         utils::download.file(url = url, destfile = mydestfile, ...)
       }

--- a/R/test_objects.R
+++ b/R/test_objects.R
@@ -9,6 +9,7 @@
 #' @export
 loadSubObjectMini = function(x, idx = 1L) {
 
+  index = path = type = NULL
   avail_obj_dt = list_subobject_mini()
   data_path = avail_obj_dt[type == x & index == idx, path]
 
@@ -23,16 +24,16 @@ loadSubObjectMini = function(x, idx = 1L) {
     original_path = load_data@file_path
     new_path = gsub(pattern = '.*[/]GiottoData/', replacement = '', x = original_path)
     new_path = paste0(gDataDir(), new_path)
-    load_data = Giotto:::reconnect_giottoLargeImage(giottoLargeImage = load_data,
-                                                    image_path = new_path)
+    load_data = GiottoClass::reconnect_giottoLargeImage(giottoLargeImage = load_data,
+                                                        image_path = new_path)
   }
 
   if(x == 'giottoImage') {
     original_path = load_data@file_path
     new_path = gsub(pattern = '.*[/]GiottoData/', replacement = '', x = original_path)
     new_path = paste0(gDataDir(), new_path)
-    load_data = Giotto:::reconnect_giottoImage_MG(giottoImage = load_data,
-                                                  image_path = new_path)
+    load_data = GiottoClass::reconnect_giottoImage_MG(giottoImage = load_data,
+                                                      image_path = new_path)
   }
 
   return(load_data)
@@ -50,6 +51,7 @@ loadSubObjectMini = function(x, idx = 1L) {
 #' @export
 listSubObjectMini = function(x = NULL) {
 
+  index = path = type = NULL
   avail_obj_dt = list_subobject_mini()
   avail_obj_dt_show = copy(avail_obj_dt)[, path := NULL]
   data.table::setcolorder(avail_obj_dt_show, neworder = c('type', 'index', 'file'))
@@ -71,6 +73,7 @@ listSubObjectMini = function(x = NULL) {
 #' @keywords internal
 list_subobject_mini = function() {
 
+  index = path = type = NULL
   miniobj_path = paste0(gDataDir(), '/Mini_objects/subobjects')
 
   avail_obj = list.files(path = miniobj_path, full.names = TRUE, recursive = TRUE)

--- a/man/getSpatialDataset.Rd
+++ b/man/getSpatialDataset.Rd
@@ -8,7 +8,7 @@ getSpatialDataset(
   dataset = c("ST_OB1", "ST_OB2", "codex_spleen", "cycif_PDAC", "starmap_3D_cortex",
     "osmfish_SS_cortex", "merfish_preoptic", "mini_seqFISH", "seqfish_SS_cortex",
     "seqfish_OB", "slideseq_cerebellum", "ST_SCC", "scRNA_prostate", "scRNA_mouse_brain",
-    "mol_cart_lung_873_C1"),
+    "mol_cart_lung_873_C1", "sg_mini_kidney"),
   directory = getwd(),
   verbose = TRUE,
   dryrun = FALSE,


### PR DESCRIPTION
- Define index, path, and type as global options to solve rcmdcheck notes. 
- Replace Giotto::reconnect_giottoLargeImage with GiottoClass::reconnect_giottoLargeImage
- Replace Giotto::wrap_msg with GiottoUtils::wrap_msg. 
- Replace set_giotto_python_path with GiottoClass::set_giotto_python_path.
-  Remove 'python_path' from changeGiottoInstructions section because is NULL and causes an error. 
- Replace Giotto::get_os with GiottoUtils::get_os 
- Update dependencies list to solve rcmdcheck warning.